### PR TITLE
Remove the scroll bar from the flag display so it doesn't hide the text on Firefox

### DIFF
--- a/src/lib/components/FlagsDisplay.svelte
+++ b/src/lib/components/FlagsDisplay.svelte
@@ -12,6 +12,6 @@
 </script>
 
 <div class="relative">
-  <pre class="rounded-md bg-secondary p-2 pr-8 font-mono text-xs"><code class="block overflow-x-auto">{textToCopy}</code></pre>
+  <pre class="rounded-md bg-secondary p-2 pr-8 font-mono text-xs"><code class="block overflow-x-auto" style="scrollbar-width: none;">{textToCopy}</code></pre>
   <CopyToClipboard variant="outline" text={textToCopy} class="absolute top-1 right-1 " />
 </div>


### PR DESCRIPTION
Here you can see what this pull request does

https://github.com/user-attachments/assets/c3f74e5d-d575-4380-9e80-22e64beac661